### PR TITLE
Verbose configuration messages and support for custom install directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,16 @@ IF(BUILD_PYTHON)
         " Will not generate setup.py for Python extension."
         )
     ELSE()
+      SET(SETUP_PY_FILEPATH ${CMAKE_CURRENT_SOURCE_DIR}/setup.py)
+      MESSAGE("Successfully generated ${SETUP_PY_FILEPATH} for the Python"
+	      " extension module. To install the Python extension module:"
+	      "\n\t0) Install the C++ library: make && make install"
+	      " (might need admin access)"
+	      "\n\t1) Go to ${CMAKE_CURRENT_SOURCE_DIR}"
+	      "\n\t2) Build the Python extension: python setup.py build"
+	      "\n\t3) Install the Python extension: python setup.py install"
+	      " (might need admin access)"
+        )
       LIST(APPEND ${PROJECT_NAME}_SRCS
         ndicapimodule.cxx
         )
@@ -77,7 +87,7 @@ IF(BUILD_PYTHON)
 
       CONFIGURE_FILE(
         ${CMAKE_CURRENT_SOURCE_DIR}/setup.py.in
-        ${CMAKE_CURRENT_SOURCE_DIR}/setup.py
+        ${SETUP_PY_FILEPATH}
         )
     ENDIF()
   ENDIF()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,9 @@ IF(BUILD_PYTHON)
   FIND_PACKAGE(PythonLibs QUIET)
   IF(PYTHONLIBS_FOUND)
     IF(NOT PYTHON_VERSION_MAJOR EQUAL 2)
-      MESSAGE("Only python2 wrapping is supported at this time.")
+      MESSAGE(WARNING "Only python2 wrapping is supported at this time."
+        " Will not generate setup.py for Python extension."
+        )
     ELSE()
       LIST(APPEND ${PROJECT_NAME}_SRCS
         ndicapimodule.cxx
@@ -72,13 +74,13 @@ IF(BUILD_PYTHON)
       LIST(APPEND ${PROJECT_NAME}_LIBS
         ${PYTHON_LIBRARIES}
         )
+
+      CONFIGURE_FILE(
+        ${CMAKE_CURRENT_SOURCE_DIR}/setup.py.in
+        ${CMAKE_CURRENT_SOURCE_DIR}/setup.py
+        )
     ENDIF()
   ENDIF()
-
-  CONFIGURE_FILE(
-    ${CMAKE_CURRENT_SOURCE_DIR}/setup.py.in
-    ${CMAKE_CURRENT_SOURCE_DIR}/setup.py
-    )
 ENDIF()
 
 FIND_PACKAGE(Threads)

--- a/setup.py.in
+++ b/setup.py.in
@@ -24,7 +24,8 @@ module1 = Extension('pyndicapi',
                     ],
                     libraries=['ndicapi'],
                     extra_link_args=extra_link_args,
-                    library_dirs=[cxx_library_dir]
+                    library_dirs=[cxx_library_dir],
+                    runtime_library_dirs=[cxx_library_dir],
                     )
 
 setup(name='pyndicapi',


### PR DESCRIPTION
* CMake now displays verbose:
  * info message if it thinks Python extension can be built
  * warning message otherwise (**no `setup.py` is generated in this case**)
* Fixed runtime discovery error in the Python module: was failing to locate the C++ library if installed in a non-standard location see 
a68dd09