### PR TITLE
Pulling changes from original repository after PR #12 accepted on original repository

### DIFF
--- a/Applications/ndiBasicExample.py
+++ b/Applications/ndiBasicExample.py
@@ -1,0 +1,53 @@
+from pyndicapi import (
+    ndiDeviceName, ndiProbe, NDI_OKAY,
+    ndiOpen, ndiClose, ndiCommand, ndiGetError,
+    ndiErrorString, NDI_115200,
+    NDI_8N1, NDI_NOHANDSHAKE,
+)
+
+
+MAX_SERIAL_PORTS = 20
+if __name__ == '__main__':
+    name = ''
+    for port_no in range(MAX_SERIAL_PORTS):
+        name = ndiDeviceName(port_no)
+        if not name:
+            continue
+        result = ndiProbe(name)
+        if result == NDI_OKAY:
+            break
+    if result != NDI_OKAY:
+        raise IOError(
+            'Could not find any NDI device in '
+            '{} serial port candidates checked. '
+            'Please check the following:\n'
+            '\t1) Is an NDI device connected to your computer?\n'
+            '\t2) Is the NDI device switched on?\n'
+            '\t3) Do you have sufficient privilege to connect to '
+            'the device? (e.g. on Linux are you part of the "dialout" '
+            'group?)'.format(MAX_SERIAL_PORTS)
+        )
+
+    device = ndiOpen(name)
+    if not device:
+        raise IOError(
+            'Could not connect to NDI device found on '
+            '{}'.format(name)
+        )
+
+    reply = ndiCommand(device, 'INIT:')
+    error = ndiGetError(device)
+    if reply.startswith('ERROR') or error != NDI_OKAY:
+        raise IOError(
+            'Error when sending command: '
+            '{}'.format(ndiErrorString(error))
+        )
+
+    reply = ndiCommand(
+        device,
+        'COMM:{:d}{:03d}{:d}'.format(NDI_115200, NDI_8N1, NDI_NOHANDSHAKE)
+    )
+
+    # Add your own commands here!!!
+
+    ndiClose(device)

--- a/ndicapimodule.cxx
+++ b/ndicapimodule.cxx
@@ -344,11 +344,21 @@ PyTypeObject PyNDIBitfield_Type =
 
 PyObject* PyNDIBitfield_FromUnsignedLong(unsigned long ival)
 {
+  return PyLong_FromUnsignedLong(ival);
+
+  /* The implementation below has been commented out,
+   * as it leads to double memory deallocation. The
+   * PyNDIBitfieldObject does not seem to be used
+   * anywhere else in the entire codebase either. So
+   * the assumption is that the above implementation
+   * of this function should not break any features.
+   *
   PyNDIBitfieldObject* v;
   v = PyObject_NEW(PyNDIBitfieldObject, &PyNDIBitfield_Type);
 
   v->ob_ival = ival;
   return (PyObject*) v;
+   */
 }
 
 /*=================================================================
@@ -562,6 +572,7 @@ static PyObject* Py_ndiOpen(PyObject* module, PyObject* args)
     }
     self = PyObject_NEW(PyNdicapi, &PyNdicapiType);
     self->pl_ndicapi = pol;
+    Py_INCREF(self);
     return (PyObject*)self;
   }
 


### PR DESCRIPTION
* ignoring PyCharm's .idea folder

* Added FIND_PACKAGE directive for pthread

* Setting CMake CXX_STANDARD to 11 (https://cmake.org/cmake/help/v3.1/prop_tgt/CXX_STANDARD.html)

* Added missing cstring include

* Fixed syntax errors in Python module's function definitions

* struct ndicapi defined in ndicapi.h instead of ndicapi.cxx

* Using proper NDIFileHandle when closing serial port

* Linking against PYTHON_LIBRARIES as well

* Using single CMake list variable for link libraries

* Ignoring Qt creator *.user file

* Renamed Python module to pyndicapi

* Added libndicapi to link libraries of Python module

* Proper indentation in setup.py

* Renamed initndicapi to initpyndicapi as the module is named pyndicapi now

* Removed PEP8-incompatible spaces from setup.py

* Added linker flags for RPATH resolution when building on a Mac

* Added more verbose Python module building instructions to README

* Changed ndicapi => pyndicapi in README as well

* Enabling python build for Win32

* Generating setup.py only for Python version 2

* Added user instructions to CMake configuration for installing Python extension, as make'ing the project does not do it

* Added runtime_library_dirs argument to Python extension, as otherwise importing fails when custom install prefix has been used for C++ lib

* Issue #4: added blank ndiBasicExample.py file

* Issue #4: displaying pyndicapi attributes

* Issue #4: replicated serial port search loop

* Issue #4: replaced all NULL returns with Py_None returns

* Issue #4: fixed formatting of IOError text when no device found

* Issue #4: checking result, not hard-coded serial port name

* Issue #4: corrected IOError text's reference to number of ports checked

* Issue #4: skipping ndiProbe on non-existing serial port candidates

* Issue #4, #5: replaced the implementation of PyNDIBitfield_FromUnsignedLong simply with the Python C API's PyLong_FromUnsignedLong function

* Issue #4, #6: incrementing reference to opened NDI device connection object before returning it to Python

* Issue #4: replicated serial port connect and disconnect

* Issue #4: replicated sending of INIT command

* Issue #4: replicated sending of COMM command

* Revert "Issue #4: replaced all NULL returns with Py_None returns"

This reverts commit 6a278e58b9401375ba3aa0e74539ffc78534dd38.